### PR TITLE
Fix/vagrant up issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "--clipboard", "bidirectional",
       "--description", "Virtual machine to develop with WordPress.com Calypso.",
       "--natdnshostresolver1", "on",
-      "--natdnsproxy1", "on"
+      "--natdnsproxy1", "on",
+      "--cableconnected1", "on"
     ]
   end
   

--- a/puppet/scripts/setup.sh
+++ b/puppet/scripts/setup.sh
@@ -47,7 +47,7 @@ apt-get install --assume-yes --quiet puppet
 
 if [[ $? -eq $TRUE ]]; then
   info "Puppet installed successfully"
-  
+
   module_list=$(puppet module list)
 
   is_module_installed puppetlabs-apt "$module_list"
@@ -66,13 +66,13 @@ if [[ $? -eq $TRUE ]]; then
     info "Puppet module 'puppetlabs-apt' already installed"
   fi
 
-  for module in puppetlabs-stdlib puppetlabs-vcsrepo
+  for module in puppetlabs-vcsrepo
   do
     is_module_installed $module "$module_list"
 
     if [[ $? -eq $FALSE ]]; then
       info "Installing Puppet module '$module'"
-      
+
       puppet module install $module
 
       if [[ $? -eq $TRUE ]]; then

--- a/puppet/scripts/setup.sh
+++ b/puppet/scripts/setup.sh
@@ -50,7 +50,23 @@ if [[ $? -eq $TRUE ]]; then
   
   module_list=$(puppet module list)
 
-  for module in puppetlabs-apt puppetlabs-stdlib puppetlabs-vcsrepo
+  is_module_installed puppetlabs-apt "$module_list"
+
+  if [[ $? -eq $FALSE ]]; then
+    info "Installing Puppet module 'puppetlabs-apt'"
+
+    puppet module install puppetlabs-apt --version 2.4.0
+
+    if [[ $? -eq $TRUE ]]; then
+      info "Puppet module 'puppetlabs-apt' installed successfully"
+    else
+      error "Unable to install Puppet module 'puppetlabs-apt'"
+    fi
+  else
+    info "Puppet module 'puppetlabs-apt' already installed"
+  fi
+
+  for module in puppetlabs-stdlib puppetlabs-vcsrepo
   do
     is_module_installed $module "$module_list"
 
@@ -67,7 +83,7 @@ if [[ $? -eq $TRUE ]]; then
     else
       info "Puppet module '$module' already installed"
     fi
-  done  
+  done
 else
   error "Unable to install Puppet"
 fi


### PR DESCRIPTION
With the latest Vagrant/Virtualbox you can't vagrant up without hitting puppet errors.

These minor changes fix things for me and let me get Calypso running.