### PR TITLE
Security: Switch to the current Ubuntu code name for the nodesource reference

### DIFF
--- a/puppet/production/modules/system/manifests/init.pp
+++ b/puppet/production/modules/system/manifests/init.pp
@@ -7,7 +7,7 @@ class system {
       server => "keyserver.ubuntu.com"
     },
     location => "https://deb.nodesource.com/node_6.x",
-    release => "precise",
+    release => "xenial",
     repos => "main"
   }
   


### PR DESCRIPTION
So we get node 6.11.1

See: https://github.com/Automattic/wp-calypso/pull/16118