### PR TITLE
Update package sources before performing `puppet` install

### DIFF
--- a/puppet/scripts/setup.sh
+++ b/puppet/scripts/setup.sh
@@ -41,6 +41,9 @@ function is_module_installed() {
 
 ## Shell ##############################################################################################################
 
+info "Updating Sources"
+apt-get update --assume-yes --quiet
+
 info "Installing Puppet"
 
 apt-get install --assume-yes --quiet puppet


### PR DESCRIPTION
An issue can occur during the puppet install where certain packages are not found. This results in a 404 error which causes the puppet install to fail.

This ulimately results in the following output:
```
The `puppet` binary appears not to be in the PATH of the guest. This
could be because the PATH is not properly setup or perhaps Puppet is not
installed on this guest. Puppet provisioning can not continue without
Puppet properly installed.
```

Running `apt-get update` beforehand helps to mitigate these 404 issues by ensuring that the sources are up to date.

Full Sample Command Line Output
```
C:\projects\wp-calypso-bootstrap [master ≡]> vagrant provision
==> wp-calypso-1.2: Running provisioner: shell...
    wp-calypso-1.2: Running: C:/.../AppData/Local/Temp/vagrant-shell20170823-12584-ho68c9.sh
==> wp-calypso-1.2: > Installing Puppet
==> wp-calypso-1.2: Reading package lists...
==> wp-calypso-1.2: Building dependency tree...
==> wp-calypso-1.2: Reading state information...
==> wp-calypso-1.2: The following additional packages will be installed:
==> wp-calypso-1.2:   augeas-lenses debconf-utils facter fonts-lato hiera javascript-common
==> wp-calypso-1.2:   libaugeas0 libjs-jquery libruby2.3 libxslt1.1 libyaml-0-2 puppet-common rake
==> wp-calypso-1.2:   ruby ruby-augeas ruby-deep-merge ruby-did-you-mean ruby-json ruby-minitest
==> wp-calypso-1.2:   ruby-net-telnet ruby-nokogiri ruby-power-assert ruby-rgen ruby-safe-yaml
==> wp-calypso-1.2:   ruby-selinux ruby-shadow ruby-test-unit ruby2.3 rubygems-integration unzip
==> wp-calypso-1.2:   virt-what zip
==> wp-calypso-1.2: Suggested packages:
==> wp-calypso-1.2:   augeas-doc mcollective-common apache2 | lighttpd | httpd augeas-tools
==> wp-calypso-1.2:   puppet-el vim-puppet etckeeper ruby-rrd ri ruby-dev bundler
==> wp-calypso-1.2: The following NEW packages will be installed:
==> wp-calypso-1.2:   augeas-lenses debconf-utils facter fonts-lato hiera javascript-common
==> wp-calypso-1.2:   libaugeas0 libjs-jquery libruby2.3 libxslt1.1 libyaml-0-2 puppet
==> wp-calypso-1.2:   puppet-common rake ruby ruby-augeas ruby-deep-merge ruby-did-you-mean
==> wp-calypso-1.2:   ruby-json ruby-minitest ruby-net-telnet ruby-nokogiri ruby-power-assert
==> wp-calypso-1.2:   ruby-rgen ruby-safe-yaml ruby-selinux ruby-shadow ruby-test-unit ruby2.3
==> wp-calypso-1.2:   rubygems-integration unzip virt-what zip
==> wp-calypso-1.2: 0 upgraded, 33 newly installed, 0 to remove and 0 not upgraded.
==> wp-calypso-1.2: Need to get 2,998 kB/8,457 kB of archives.
==> wp-calypso-1.2: After this operation, 38.8 MB of additional disk space will be used.
==> wp-calypso-1.2: Err:1 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libruby2.3 amd64 2.3.1-2~16.04
==> wp-calypso-1.2:   404  Not Found [IP: 91.189.91.23 80]
==> wp-calypso-1.2: Err:2 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 ruby2.3 amd64 2.3

.1-2~16.04
==> wp-calypso-1.2:   404  Not Found [IP: 91.189.91.23 80]
==> wp-calypso-1.2: E
==> wp-calypso-1.2: :
==> wp-calypso-1.2: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/r/ruby2.3/libruby2.3_2.

3.1-2~16.04_amd64.deb  404  Not Found [IP: 91.189.91.23 80]
==> wp-calypso-1.2: E
==> wp-calypso-1.2: :
==> wp-calypso-1.2: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/r/ruby2.3/ruby2.3_2.3.1

-2~16.04_amd64.deb  404  Not Found [IP: 91.189.91.23 80]
==> wp-calypso-1.2: E
==> wp-calypso-1.2: :
==> wp-calypso-1.2: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
==> wp-calypso-1.2: ! Unable to install Puppet
==> wp-calypso-1.2: Running provisioner: puppet...
The `puppet` binary appears not to be in the PATH of the guest. This
could be because the PATH is not properly setup or perhaps Puppet is not
installed on this guest. Puppet provisioning can not continue without
Puppet properly installed.
```