### PR TITLE
Replace "make run" with "npm start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ vagrant@calypso:~$ cd /var/sources
 And start the application with:
 
 ```
-vagrant@calypso:/var/sources$ make run
+vagrant@calypso:/var/sources$ npm start
 ```
 
 This will build Calypso, which can be a lengthy process the first time it is run because that will download all dependencies. Hopefully at some point you'll see:


### PR DESCRIPTION
This is in reference to Issue (#14631) on the wp-calypso repository https://github.com/Automattic/wp-calypso/pull/14631/files removing makefile functionality. Updating bootstrap documentation to reflect this to run "npm start" instead of "make run" after the virtual machine is running.