### PR TITLE
Update Ubuntu to latest version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,25 +4,22 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.define "wp-calypso-1.4" do |node|
-    node.vm.box = "bento/ubuntu-16.04"
+  config.vm.define "wp-calypso-1.5" do |node|
+    node.vm.box = "bento/ubuntu-18.04"
     node.vm.host_name = "calypso.automattic.com"
-    
+
     node.vm.network :forwarded_port, guest: 3000, host: 3000
     node.vm.network :forwarded_port, guest: 9898, host: 9898
   end
-  
-  # Fixes a 'stdin: is not a tty' error (see http://bit.ly/1nokaAw)
-  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-  
+
   # Disables default synced folders
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  
+
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "Calypso Bootstrap 1.4"
+    vb.name = "Calypso Bootstrap 1.5"
     vb.cpus = 2
     vb.memory = 4096
-    
+
     vb.customize [
       "modifyvm", :id,
       "--clipboard", "bidirectional",
@@ -32,15 +29,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "--cableconnected1", "on"
     ]
   end
-  
+
   # Installs the latest versions of Puppet third-party modules
   config.vm.provision "shell", path: "puppet/scripts/setup.sh"
-  
+
   config.vm.provision "puppet" do |puppet|
     puppet.environment = "production"
     puppet.environment_path = "puppet"
   end
-  
+
   config.vm.post_up_message = "             _
     ___ __ _| |_   _ _ __  ___  ___
    / __/ _` | | | | | '_ \\/ __|/ _ \\

--- a/puppet/production/modules/bash/files/.screenrc
+++ b/puppet/production/modules/bash/files/.screenrc
@@ -1,7 +1,7 @@
 #######################################################################################################################
-# 
+#
 # GNU Screen Configuration
-# 
+#
 
 
 
@@ -11,7 +11,7 @@ defutf8 on
 # Disables the presentation page
 startup_message off
 
-# Disables flashing of the screen when the shell rings the terminal bell (e.g. when performing autocompletion which 
+# Disables flashing of the screen when the shell rings the terminal bell (e.g. when performing autocompletion which
 # would return lots of possibilities)
 vbell off
 

--- a/puppet/production/modules/github/manifests/ssh_keys.pp
+++ b/puppet/production/modules/github/manifests/ssh_keys.pp
@@ -5,7 +5,7 @@ class github::ssh_keys {
     owner  => "root",
     group  => "root"
   }
-  
+
   # Copies the private deploy key of the GitHub Calypso repository on the guest system
   file { "/root/.ssh/id_rsa":
     ensure  => present,

--- a/puppet/production/modules/motd/files/00-header
+++ b/puppet/production/modules/motd/files/00-header
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Displays the following text banner generated with 'figlet -c -w 40 "calypso"'. The output of this command was first 
+# Displays the following text banner generated with 'figlet -c -w 40 "calypso"'. The output of this command was first
 # pasted below and then any backquote (anywhere) and backslash (located at the end of a line) was escaped with slashes.
 echo "             _
     ___ __ _| |_   _ _ __  ___  ___

--- a/puppet/production/modules/system/manifests/init.pp
+++ b/puppet/production/modules/system/manifests/init.pp
@@ -29,7 +29,7 @@ class system {
 
   file_line { "increase file watcher system limit":
     ensure => present,
-    line   => "fs.inotify.max_user_watches=16384",
+    line   => "fs.inotify.max_user_watches=25000",
     path   => "/etc/sysctl.conf"
   }
 

--- a/puppet/production/modules/system/manifests/init.pp
+++ b/puppet/production/modules/system/manifests/init.pp
@@ -4,11 +4,9 @@ class system {
   apt::source { "nodejs":
     key => {
       id => "9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280",
-      server => "keyserver.ubuntu.com"
+      server => "hkp://keyserver.ubuntu.com:80"
     },
-    location => "https://deb.nodesource.com/node_10.x",
-    release => "xenial",
-    repos => "main"
+    location => "https://deb.nodesource.com/node_10.x"
   }
 
   exec { "update":
@@ -16,15 +14,10 @@ class system {
     require => Apt::Source["nodejs"]
   }
 
-  # Fixes a circular dependency issue (http://unix.stackexchange.com/a/202990)
-  exec { "remove keyboard configuration":
-    command => "/usr/bin/apt-get remove --assume-yes keyboard-configuration",
-    require => Exec["update"]
-  }
 
   exec { "install keyboard configuration":
     command => "/usr/bin/apt-get install --assume-yes keyboard-configuration",
-    require => Exec["remove keyboard configuration"]
+    require => Exec["update"]
   }
 
   exec { "upgrade":
@@ -39,7 +32,7 @@ class system {
     line   => "fs.inotify.max_user_watches=16384",
     path   => "/etc/sysctl.conf"
   }
-  
+
   exec { "make new file watcher system limit effective":
     command => "/sbin/sysctl -p",
     require => File_line["increase file watcher system limit"]

--- a/puppet/production/modules/unison/manifests/init.pp
+++ b/puppet/production/modules/unison/manifests/init.pp
@@ -1,10 +1,10 @@
 class unison {
   exec { "download":
-    command => "/usr/bin/wget --content-disposition https://www.archlinux.org/packages/extra/x86_64/unison/download/ -O /tmp/unison-2.48.3-2-x86_64.pkg.tar.xz"
+    command => "/usr/bin/wget --content-disposition https://archive.archlinux.org/packages/u/unison/unison-2.48.15-3-x86_64.pkg.tar.xz --directory-prefix=/tmp"
   }
-  
+
   exec { "uncompress":
-    command => "/bin/tar xf /tmp/unison-2.48.3-2-x86_64.pkg.tar.xz -C /",
+    command => "/bin/tar xf /tmp/unison-2.48.15-3-x86_64.pkg.tar.xz -C /",
     require => Exec["download"]
   }
 }

--- a/puppet/scripts/setup.sh
+++ b/puppet/scripts/setup.sh
@@ -54,23 +54,7 @@ if [[ $? -eq $TRUE ]]; then
 
   module_list=$(puppet module list)
 
-  is_module_installed puppetlabs-apt "$module_list"
-
-  if [[ $? -eq $FALSE ]]; then
-    info "Installing Puppet module 'puppetlabs-apt'"
-
-    puppet module install puppetlabs-apt --version 2.4.0
-
-    if [[ $? -eq $TRUE ]]; then
-      info "Puppet module 'puppetlabs-apt' installed successfully"
-    else
-      error "Unable to install Puppet module 'puppetlabs-apt'"
-    fi
-  else
-    info "Puppet module 'puppetlabs-apt' already installed"
-  fi
-
-  for module in puppetlabs-vcsrepo
+  for module in puppetlabs-apt puppetlabs-vcsrepo
   do
     is_module_installed $module "$module_list"
 


### PR DESCRIPTION
This pull request updates Ubuntu to version [18.04 LTS](https://wiki.ubuntu.com/Releases). It also removes a few fixes that should no longer be needed, and fixes a wrong `unison` version as well as a connectivity issue with the Ubuntu key server.

#### Testing instructions
 
1. Run `git checkout update/ubuntu`
2. Run `vagrant up`
3. Log in to the virtual machine, and head to the `/var/sources` directory
4. Run `npm start` to start the application
5. Open the [`Home` page](http://calypso.localhost:3000/)
6. Assert that the application works as usual