### PR TITLE
Switch to Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note this installation process **can take quite some time** the first time you p
 
 1. Download an image of the current stable version of Ubuntu
 2. Load it into the virtual machine and update it
-3. Install all necessary packages such as Git, Node.js, or NPM
+3. Install all necessary packages such as Git, Node.js, or Yarn
 4. Download the Calypso repository
 
 Finally, just add `127.0.0.1 calypso.localhost` to your `hosts` file.
@@ -88,13 +88,19 @@ Now simply head to the Calypso directory:
 vagrant@calypso:~$ cd /var/sources
 ```
 
-And start the application with:
+And install dependencies with:
 
 ```
-vagrant@calypso:/var/sources$ npm start
+vagrant@calypso:/var/sources$ yarn
 ```
 
-This will build Calypso, which can be a lengthy process the first time it is run because that will download all dependencies. Hopefully at some point you'll see:
+Start the application with:
+
+```
+vagrant@calypso:/var/sources$ yarn start
+```
+
+This will build Calypso, which can be a lengthy process. Hopefully at some point you'll see:
 
 ```
 Ready! You can load http://calypso.localhost:3000/ now. Have fun!

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.define "wp-calypso-1.6" do |node|
+  config.vm.define "wp-calypso-1.7" do |node|
     node.vm.box = "bento/ubuntu-18.04"
     node.vm.host_name = "calypso.automattic.com"
 
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "Calypso Bootstrap 1.6"
+    vb.name = "Calypso Bootstrap 1.7"
     vb.cpus = 2
     vb.memory = 4096
 

--- a/puppet/production/manifests/default.pp
+++ b/puppet/production/manifests/default.pp
@@ -12,3 +12,4 @@ include motd
 include nodejs
 include system
 include unison
+include yarn

--- a/puppet/production/modules/bash/files/.bash_aliases
+++ b/puppet/production/modules/bash/files/.bash_aliases
@@ -4,12 +4,12 @@ alias l="ls --almost-all --group-directories-first -l --time-style=long-iso"
 
 # Calypso aliases
 alias cds="cd /var/sources"
-alias nc="npm run clean"
-alias ndc="npm run distclean"
-alias ns="npm start"
-alias nl="npm run lint"
-alias nlb="npm run eslint-branch"
-alias nt="npm test"
+alias nc="yarn clean"
+alias ndc="yarn distclean"
+alias ns="yarn start"
+alias nl="yarn lint"
+alias nlb="yarn eslint-branch"
+alias nt="yarn test"
 
 # Git aliases
 alias gb="git branch"

--- a/puppet/production/modules/github/manifests/known_hosts.pp
+++ b/puppet/production/modules/github/manifests/known_hosts.pp
@@ -9,7 +9,7 @@ class github::known_hosts {
   # Adds GitHub host signature in this system file to prevent manual confirmation during repository cloning. The key
   # below is generated manually based on official fingerprints available at http://bit.ly/1spcKuZ.
   sshkey { "github.com":
-    ensure => "present",
+    ensure => present,
     key    => "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
     type   => "ssh-rsa"
   }

--- a/puppet/production/modules/system/manifests/init.pp
+++ b/puppet/production/modules/system/manifests/init.pp
@@ -9,9 +9,19 @@ class system {
     location => "https://deb.nodesource.com/node_12.x"
   }
 
+  apt::source { "yarn":
+    key => {
+      id => "72ECF46A56B4AD39C907BBB71646B01B86E50310",
+      source => "https://dl.yarnpkg.com/debian/pubkey.gpg"
+    },
+    location => "https://dl.yarnpkg.com/debian/",
+    release  => "stable",
+    repos    => "main"
+  }
+
   exec { "update system":
     command => "/usr/bin/apt-get update",
-    require => Apt::Source["nodejs"]
+    require => [Apt::Source["nodejs"], Apt::Source["yarn"]]
   }
 
   exec { "upgrade system":

--- a/puppet/production/modules/yarn/manifests/init.pp
+++ b/puppet/production/modules/yarn/manifests/init.pp
@@ -1,0 +1,5 @@
+class yarn {
+  package { "yarn":
+    ensure => latest
+  }
+}


### PR DESCRIPTION
This pull request updates Calyso Bootstrap to use Yarn per https://github.com/Automattic/wp-calypso/issues/40882.