### PR TITLE
Get working on latest wp-calypso and with updated clipboard-mode param

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     vb.customize [
       "modifyvm", :id,
-      "--clipboard", "bidirectional",
+      "--clipboard-mode", "bidirectional",
       "--description", "Virtual machine to develop with WordPress.com Calypso.",
       "--natdnshostresolver1", "on",
       "--natdnsproxy1", "on",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     vb.customize [
       "modifyvm", :id,
-      "--clipboard-mode", "bidirectional",
+      "--clipboard", "bidirectional",
       "--description", "Virtual machine to develop with WordPress.com Calypso.",
       "--natdnshostresolver1", "on",
       "--natdnsproxy1", "on",

--- a/puppet/production/modules/github/manifests/init.pp
+++ b/puppet/production/modules/github/manifests/init.pp
@@ -9,7 +9,7 @@ class github {
   vcsrepo { "/var/sources":
     ensure   => present,
     provider => git,
-    revision => "master",
+    revision => "trunk",
     source   => "git@github.com:Automattic/wp-calypso.git",
     owner    => "vagrant",
     group    => "vagrant",


### PR DESCRIPTION
The latest https://github.com/Automattic/wp-calypso uses `trunk` as the mainline branch instead of `master`. Also the `clipboard` parameter has been changed to `clipboard-mode`. These two changes make this project usable as of today.