### PR TITLE
Update Ubuntu to 23.04 and Node to 18

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.define "wp-calypso-1.9" do |node|
-    node.vm.box = "bento/ubuntu-20.04"
+  config.vm.define "wp-calypso-1.10" do |node|
+    node.vm.box = "bento/ubuntu-23.04"
     node.vm.host_name = "calypso.automattic.com"
 
     node.vm.network :forwarded_port, guest: 3000, host: 3000
@@ -16,9 +16,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "Calypso Bootstrap 1.9"
-    vb.cpus = 2
-    vb.memory = 4096
+    vb.name = "Calypso Bootstrap 1.10"
+    vb.cpus = 4
+    vb.memory = 12000
 
     vb.customize [
       "modifyvm", :id,

--- a/puppet/production/modules/bash/files/.bash_aliases
+++ b/puppet/production/modules/bash/files/.bash_aliases
@@ -18,7 +18,7 @@ alias gcp="git cherry-pick"
 alias gd="git diff"
 alias gf="git fetch"
 alias gl="git log --abbrev-commit --pretty=format:'%Cred%h%Creset%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)%an%Creset'"
-alias gp="git push"
+alias gp="git pull -p"
 alias gr="git diff --name-only master"
 alias gs="git status"
 

--- a/puppet/production/modules/github/manifests/known_hosts.pp
+++ b/puppet/production/modules/github/manifests/known_hosts.pp
@@ -7,10 +7,10 @@ class github::known_hosts {
   }
 
   # Adds GitHub host signature in this system file to prevent manual confirmation during repository cloning. The key
-  # below is generated manually based on official fingerprints available at http://bit.ly/1spcKuZ.
+  # below is based on official fingerprints and was taken from http://bit.ly/1spcKuZ.
   sshkey { "github.com":
     ensure => present,
-    key    => "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
+    key    => "AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=",
     type   => "ssh-rsa"
   }
 }

--- a/puppet/production/modules/system/manifests/init.pp
+++ b/puppet/production/modules/system/manifests/init.pp
@@ -6,7 +6,7 @@ class system {
       id => "9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280",
       server => "hkp://keyserver.ubuntu.com:80"
     },
-    location => "https://deb.nodesource.com/node_14.x"
+    location => "https://deb.nodesource.com/node_18.x"
   }
 
   apt::source { "yarn":

--- a/puppet/production/modules/yarn/manifests/init.pp
+++ b/puppet/production/modules/yarn/manifests/init.pp
@@ -13,7 +13,7 @@ class yarn {
 
   file_line { "increase Node memory limit":
     ensure => present,
-    line   => "NODE_OPTIONS=--max-old-space-size=3000",
+    line   => "NODE_OPTIONS=--max-old-space-size=11000",
     path   => "/etc/environment"
   }
 }

--- a/puppet/scripts/setup.sh
+++ b/puppet/scripts/setup.sh
@@ -54,7 +54,7 @@ if [[ $? -eq $TRUE ]]; then
 
   module_list=$(puppet module list)
 
-  for module in puppetlabs-apt puppetlabs-vcsrepo
+  for module in puppetlabs-apt puppetlabs-sshkeys_core puppetlabs-vcsrepo
   do
     is_module_installed $module "$module_list"
 


### PR DESCRIPTION
This pull request updates Ubuntu to version [23.04](https://wiki.ubuntu.com/Releases) and Node to 18 (see https://github.com/Automattic/wp-calypso/pull/72245). It also performs various performance adjustments, and fixes a wrong fingerprint for GitHub.

#### Testing instructions
 
1. Run `git checkout upgrade`
2. Run `vagrant up`
3. Log in to the virtual machine, and head to the `/var/sources` directory
4. Run `npm start` to start the application
5. Open the [`Home` page](http://calypso.localhost:3000/)
6. Assert that the application works as usual